### PR TITLE
Preinstall C compiler in 10.0-pg10-fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,10 +74,10 @@ ONBUILD RUN chmod -R u=rwX,go=rX /mnt/extra-addons-bundles
 ONBUILD COPY ./build-hooks/ /root/build-hooks/
 ONBUILD COPY ./requirements.txt /root/
 ONBUILD RUN \
-    pre_pip_hook="/root/build-hooks/pre-pip.sh" \
-    if [ -f "$pre_pip_hook" ] \
+    pre_pip_hook="/root/build-hooks/pre-pip.sh" ; \
+    if [ -f "$pre_pip_hook" ] ; \
     then \
-        /bin/bash -x -e "$pre_pip_hook" \
+        /bin/bash -x -e "$pre_pip_hook" ; \
     fi
 ONBUILD RUN pip install -r /root/requirements.txt
 # Remove compiler for security in production

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,10 @@ RUN set -ex; \
     echo "deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main $PG_MAJOR" > /etc/apt/sources.list.d/pgdg.list; \
             apt-get update ; \
 apt-get -y install "postgresql-client-$PG_MAJOR" postgresql-client-9.4-
+# So future apt-get update calls don't have to download the full Postgres
+# package list each time:
+RUN rm /etc/apt/sources.list.d/pgdg.list
+
 
 # Install barcode font
 COPY pfbfer.zip /root/pfbfer.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,21 @@ USER odoo
 ONBUILD USER root
 ONBUILD COPY ./addon-bundles/ /mnt/extra-addons-bundles/
 ONBUILD RUN chmod -R u=rwX,go=rX /mnt/extra-addons-bundles
+# If copy of build-hooks breaks your build:
+#  mkdir build-hooks
+#  touch build-hooks/.gitkeep
+#  git add build-hooks/.gitkeep
+# Introducing a directory for hooks means we can add more in
+# future and allow you to add your own helper scripts without
+# breaking the build again.
+ONBUILD COPY ./build-hooks/ /root/build-hooks/
 ONBUILD COPY ./requirements.txt /root/
+ONBUILD RUN \
+    pre_pip_hook="/root/build-hooks/pre-pip.sh"
+    if [ -f "$pre_pip_hook" ] \
+    then \
+        /bin/bash -x -e "$pre_pip_hook" \
+    fi
 ONBUILD RUN pip install -r /root/requirements.txt
 # Remove compiler for security in production
 ONBUILD RUN apt-get -y autoremove gcc g++

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,10 @@ ONBUILD RUN \
     pre_pip_hook="/root/build-hooks/pre-pip.sh" ; \
     if [ -f "$pre_pip_hook" ] ; \
     then \
-        /bin/bash -x -e "$pre_pip_hook" ; \
+        /bin/bash -x -e "$pre_pip_hook" \
+            # reduce size of layer - probably last time we'll install anything using apt anyway \
+            && rm -rf /var/lib/apt/lists/* \
+            ; \
     fi
 ONBUILD RUN pip install -r /root/requirements.txt
 # Remove compiler for security in production

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,4 +66,5 @@ ONBUILD COPY ./addon-bundles/ /mnt/extra-addons-bundles/
 ONBUILD RUN chmod -R u=rwX,go=rX /mnt/extra-addons-bundles
 ONBUILD COPY ./requirements.txt /root/
 ONBUILD RUN pip install -r /root/requirements.txt
-
+# Remove compiler for security in production
+ONBUILD RUN apt-get -y autoremove gcc g++

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ ONBUILD RUN chmod -R u=rwX,go=rX /mnt/extra-addons-bundles
 ONBUILD COPY ./build-hooks/ /root/build-hooks/
 ONBUILD COPY ./requirements.txt /root/
 ONBUILD RUN \
-    pre_pip_hook="/root/build-hooks/pre-pip.sh"
+    pre_pip_hook="/root/build-hooks/pre-pip.sh" \
     if [ -f "$pre_pip_hook" ] \
     then \
         /bin/bash -x -e "$pre_pip_hook" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER OpusVL <community@opusvl.com>
 
 USER root
 
-# Install some more fonts and locales
+# Install some more fonts and locales, and common build requirements
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         fonts-dejavu \
@@ -14,6 +14,8 @@ RUN apt-get update \
         locales-all \
         locales \
         gnupg \
+        build-essential \
+        python2.7-dev \
     && rm -rf /var/lib/apt/lists/*
 
 ### MAKE DATABASE MANAGER WORK WITH PostgreSQL 10 ###

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ So you can check out a set of modules directly into there (in a volume or copied
 Create a git repo with the following structure:
 
 * a directory `addons-bundles` containing the repositories we are using modules from as git submodules (though sometimes customer-specific modules live in a plain subdirectory of this directory).  Can be empty but must be there.  Use a .gitkeep file if necessary.
+* a directory `build-hooks`
+  * `build-hooks` must exist but may be empty.  Use a `build-hooks/.gitkeep` file to make sure it's checked into git. 
+  * if you need to install packages before your `requirements.txt` is processed, include a bash script `build-hooks/pre-pip.sh`
+    * it is called with `bash -e`, therefore:
+      * it doesn't need to be executable or have a `#!` line
+      * the first command that fails will stop the build
+      * if you call your own scripts from the hook, make sure they exit with non-zero on failure  
 * a `requirements.txt` listing extra modules to install via pip.  Can be empty but must be there.
 * a `Dockerfile`
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Create a git repo with the following structure:
 * a directory `build-hooks`
   * `build-hooks` must exist but may be empty.  Use a `build-hooks/.gitkeep` file to make sure it's checked into git. 
   * if you need to install packages before your `requirements.txt` is processed, include a bash script `build-hooks/pre-pip.sh`
+    * it is up to you to run `apt-get update` before `apt-get install -y`
     * it is called with `bash -e`, therefore:
       * it doesn't need to be executable or have a `#!` line
       * the first command that fails will stop the build

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ There is a new entrypoint `opusvl-entrypoint.py` which augments environment vari
 
 # Copyright and License
 
-Copyright (C) 2017  Opus Vision Limited
+Copyright (C) 2019  Opus Vision Limited
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ This is for backwards compatibility with existing environments that are configur
 
 There is a new entrypoint `opusvl-entrypoint.py` which augments environment variables and the command line with its own stuff depending on environment variables you set and what it finds in `/mnt/extra-addons-bundles`, then despatches to the upstream `entrypoint.sh`, re-using the logic contained therein.
 
+# No promises about build breakage
+
+Sometimes to add features we will have to break the build of your derived containers.  Caveat emptor.
+
+* Upgrading to a version that uses a `build-hooks` directory will break your build
+  * A comment in Dockerfile explains how to remedy this in your repository
 
 # Copyright and License
 


### PR DESCRIPTION
Closes #11 

I think we've proven this now.  Remember that any other projects extending 10.0-pg10-fix will need to have some minor changes made to them in order to build, as documented in README.md