### PR TITLE
8.0 odoo base fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,6 @@ RUN apt-get update \
         locales \
     && rm -rf /var/lib/apt/lists/*
 
-
-# Install barcode font
-RUN curl http://www.reportlab.com/ftp/pfbfer.zip --output /tmp/pfbfer.zip \
-        && mkdir -p /usr/lib/python2.7/dist-packages/reportlab/fonts \
-        && unzip /tmp/pfbfer.zip -d /usr/lib/python2.7/dist-packages/reportlab/fonts/
-
 # Generate British locales, as this is who we mostly serve
 RUN locale-gen en_GB.UTF-8
 ENV LANG en_GB.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM odoo:8.0
+FROM quay.io/opusvl/odoo:8.0
 MAINTAINER OpusVL <community@opusvl.com>
 
 USER root


### PR DESCRIPTION
Changes the FROM to use Opus VL Odoo 8.0 image as the official one is dead. Also removes the barcode install as that is now part of the Odoo 8.0 image.