### PR TITLE
Note deprecation and where to find new versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,8 @@
-# docker-odoo-custom
-An Odoo docker image with extended capabilities and fixes over the official one.
+# DEPRECATED docker-odoo-custom:11.0
 
-Some of these are development aids, while some make a difference to how images
-are built for production.
+This is now deprecated for version 11, please use https://github.com/OpusVL/docker-custom-odoo-11 instead.
 
-[![Docker Repository on Quay](https://quay.io/repository/opusvl/odoo-custom/status "Docker Repository on Quay")](https://quay.io/repository/opusvl/odoo-custom)
-
-# Locales
-
-Locales are generated for en_GB, and are set as default in the environment.
-
-# Extra fonts
-
-* fonts-dejavu
-* fonts-dejavu-extra
-* Reportlab barcode font
-
-# Addons Bundles
-
-An `--addons-path` argument is automatically built on each startup to contain any subdirectories within `/mnt/extra-addons-bundles` that contain at least one valid Odoo addon.  This could be a checkout of a repository from https://github.com/OCA for example.
-
-So you can check out a set of modules directly into there (in a volume or copied in via a Dockerfile extending this one) and have Odoo pick them up, instead of having to flatten the tree yourself or manually build an addons_path in the config file.
-
-## How to base your own image off this
-
-Create a git repo with the following structure:
-
-* a directory `addons-bundles` containing the repositories we are using modules from as git submodules (though sometimes customer-specific modules live in a plain subdirectory of this directory).  Can be empty but must be there.  Use a .gitkeep file if necessary.
-* a `requirements.txt` listing extra modules to install via pip.  Can be empty but must be there.
-* a `Dockerfile`
-
-The Dockerfile might have something like this in it:
-
-```
-FROM quay.io/opusvl/odoo-custom:10.0
-```
-
-# Run Odoo from a git checkout
-
-Setting the `DEV_ODOO` environment variable to a path, e.g. `/opt/odoo`, where you have
-mounted a git clone of an Odoo source tree, will cause that path to be prepended to the
-PATH and the default addons path to point to it.
-
-# Old DB config environment variables still work
-
-EXPERIMENTAL
-
-The `DB*` environment variables we have in our existing docker-compose setups are, if set, copied to the new equivalents as of about 6 months ago.
-
-This is for backwards compatibility with existing environments that are configured using the `DB*` variables.  If they are set, then they will override the official ones - depending on internal feedback or feedback from you, the community, we may change the priorities so consider this particular bit experimental.
-
-
-# How it works
-
-There is a new entrypoint `opusvl-entrypoint.py` which augments environment variables and the command line with its own stuff depending on environment variables you set and what it finds in `/mnt/extra-addons-bundles`, then despatches to the upstream `entrypoint.sh`, re-using the logic contained therein.
+The 11.0 branch of this repository will be kept for backwards-compatibility only.
 
 
 # Copyright and License


### PR DESCRIPTION
Note we must have set https://github.com/OpusVL/docker-custom-odoo-11 as public before we review and merge this in.  This means having finished milestone https://github.com/OpusVL/docker-custom-odoo-11/milestone/1